### PR TITLE
chore (pacakges): adding status filter endpoint

### DIFF
--- a/src/packages/constants/index.ts
+++ b/src/packages/constants/index.ts
@@ -1,0 +1,7 @@
+export const PACAKGE_STATUSES = [
+	'PENDIENTE',
+	'EN CURSO',
+	'unassigned',
+	'ENTREGADO',
+]
+export type PackageStatus = (typeof PACAKGE_STATUSES)[number]

--- a/src/packages/packages.controller.ts
+++ b/src/packages/packages.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Body, Param, Put } from '@nestjs/common'
 import { PackagesService } from './packages.service'
 import { PackageDto } from './dto/package.dto'
 import { UpdatePackageDto } from './dto/update-package.dto'
+import { PackageStatus } from './constants'
 
 @Controller('packages')
 export class PackagesController {
@@ -14,6 +15,10 @@ export class PackagesController {
 	@Get(':id')
 	findBy(@Param('id') id: string) {
 		return this.packageService.findByID(id)
+	}
+	@Get('/status/:status')
+	findByStatus(@Param('status') status: PackageStatus) {
+		return this.packageService.findByStatus(status)
 	}
 
 	@Post()

--- a/src/packages/packages.service.ts
+++ b/src/packages/packages.service.ts
@@ -4,6 +4,7 @@ import { Package, PackageDocument } from './schema/packages.schema'
 import { Model } from 'mongoose'
 import { PackageDto } from './dto/package.dto'
 import { UpdatePackageDto } from './dto/update-package.dto'
+import { PackageStatus } from './constants'
 
 @Injectable()
 export class PackagesService {
@@ -22,7 +23,9 @@ export class PackagesService {
 	async findByID(id: string) {
 		return this.PackageModel.findById(id)
 	}
-
+	async findByStatus(status: PackageStatus) {
+		return this.PackageModel.find({ status })
+	}
 	async update(_id: string, data: UpdatePackageDto) {
 		return await this.PackageModel.findOneAndUpdate({ _id }, data, {
 			returnOriginal: false,


### PR DESCRIPTION
Nuevo endpoint para solicitar paquetes segun su status:

`http://localhost:3001/api/packages/status/${status}.`

Ejemplo:

![image](https://github.com/Francisco-Villanueva/box-api/assets/90634174/733a5d6b-177b-429c-8b94-7906060a754d)
![image](https://github.com/Francisco-Villanueva/box-api/assets/90634174/14964230-a1b1-4e50-9ba3-121bf8561b66)
