### PR TITLE
feat(API): swagger install & config for endpoints documentation

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,7 @@
 	"collection": "@nestjs/schematics",
 	"sourceRoot": "src",
 	"compilerOptions": {
-		"deleteOutDir": true
+		"deleteOutDir": true,
+		"plugins": ["@nestjs/swagger"]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@nestjs/mapped-types": "*",
 				"@nestjs/mongoose": "^10.0.2",
 				"@nestjs/platform-express": "^10.0.0",
+				"@nestjs/swagger": "^7.1.17",
 				"@nestjs/typeorm": "^10.0.1",
 				"@types/multer": "^1.4.11",
 				"aws-sdk": "^2.1515.0",
@@ -1908,6 +1909,37 @@
 				"typescript": ">=4.8.2"
 			}
 		},
+		"node_modules/@nestjs/swagger": {
+			"version": "7.1.17",
+			"resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.1.17.tgz",
+			"integrity": "sha512-ASCxBrvMEN2o/8vEEmrIPMNzrr/hVi7QIR4y1oNYvoBNXHuwoF1VSI3+4Rq/3xmwVnVveJxHlBIs2u5xY9VgGQ==",
+			"dependencies": {
+				"@nestjs/mapped-types": "2.0.4",
+				"js-yaml": "4.1.0",
+				"lodash": "4.17.21",
+				"path-to-regexp": "3.2.0",
+				"swagger-ui-dist": "5.10.3"
+			},
+			"peerDependencies": {
+				"@fastify/static": "^6.0.0",
+				"@nestjs/common": "^9.0.0 || ^10.0.0",
+				"@nestjs/core": "^9.0.0 || ^10.0.0",
+				"class-transformer": "*",
+				"class-validator": "*",
+				"reflect-metadata": "^0.1.12"
+			},
+			"peerDependenciesMeta": {
+				"@fastify/static": {
+					"optional": true
+				},
+				"class-transformer": {
+					"optional": true
+				},
+				"class-validator": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@nestjs/testing": {
 			"version": "10.2.8",
 			"resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.2.8.tgz",
@@ -3029,8 +3061,7 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"node_modules/array-flatten": {
 			"version": "1.1.1",
@@ -7902,7 +7933,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -11900,6 +11930,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/swagger-ui-dist": {
+			"version": "5.10.3",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.10.3.tgz",
+			"integrity": "sha512-fu3aozjxFWsmcO1vyt1q1Ji2kN7KlTd1vHy27E9WgPyXo9nrEzhQPqgxaAjbMsOmb8XFKNGo4Sa3Q+84Fh+pFw=="
 		},
 		"node_modules/symbol-observable": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"@nestjs/mapped-types": "*",
 		"@nestjs/mongoose": "^10.0.2",
 		"@nestjs/platform-express": "^10.0.0",
+		"@nestjs/swagger": "^7.1.17",
 		"@nestjs/typeorm": "^10.0.1",
 		"@types/multer": "^1.4.11",
 		"aws-sdk": "^2.1515.0",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,10 +1,15 @@
 import { Controller, Get } from '@nestjs/common'
 import { AppService } from './app.service'
+import { ApiOperation, ApiTags } from '@nestjs/swagger'
 
+@ApiTags('Main')
 @Controller()
 export class AppController {
 	constructor(private readonly appService: AppService) {}
 
+	@ApiOperation({
+		description: 'Retrieve a greeting message from the application',
+	})
 	@Get()
 	getHello(): string {
 		return this.appService.getHello()

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,16 +15,23 @@ import { ResetPasswordDto } from './dto/resetPass-auth.dto'
 import { UpdatePasswordDto } from './dto/updatePass-auth.dto'
 import { ValidateTokenDTO } from './dto/token.dto'
 import { FileInterceptor } from '@nestjs/platform-express'
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger'
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
 	constructor(private readonly authService: AuthService) {}
 
+	@ApiOperation({
+		description: 'Retrieve a greeting message from the application',
+	})
 	@Get()
 	sayHello() {
 		return 'Hello Packages'
 	}
 
+	@ApiOperation({ description: 'Authenticate and generate JWT for user login' })
+	@ApiBody({ type: LoginAuthDto })
 	@Post('login')
 	async login(@Body() { user, password }: LoginAuthDto) {
 		const userValidate = await this.authService.validateUser(user, password)
@@ -38,27 +45,36 @@ export class AuthController {
 		return jwt
 	}
 
+	@ApiOperation({ description: 'Register a new user' })
+	@ApiBody({ type: UserDTO })
 	@Post('register')
 	registerUser(@Body() userObjectRegister: UserDTO) {
 		return this.authService.register(userObjectRegister)
 	}
 
+	@ApiOperation({ description: 'Retrieve user information based on JWT token' })
+	@ApiBody({ type: ValidateTokenDTO })
 	@Post('me')
 	me(@Body() token: ValidateTokenDTO) {
 		return this.authService.me(token.token)
 	}
 
+	@ApiOperation({ description: 'Reset user password' })
+	@ApiBody({ type: ResetPasswordDto })
 	@Post('reset-password')
 	resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
 		return this.authService.resetPassword(resetPasswordDto)
 	}
 
+	@ApiOperation({ description: 'Update user password' })
+	@ApiBody({ type: UpdatePasswordDto })
 	@Patch('update-password')
 	updatePassword(@Body() updatePasswordDto: UpdatePasswordDto) {
 		return this.authService.updatePassword(updatePasswordDto)
 	}
 
 	//Endpoint para mandar la imagen desde el front. Le retorna al front la url de S3
+	@ApiOperation({ description: 'Upload an image and get the S3 URL' })
 	@Post('upload-image')
 	@UseInterceptors(FileInterceptor('image'))
 	async uploadImage(@UploadedFile() file: Express.Multer.File) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module'
 import { checkEnvVariables } from 'config/envCheck'
 import * as morgan from 'morgan'
 import { CORS } from './constants'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 
 async function bootstrap() {
 	await checkEnvVariables()
@@ -12,6 +13,14 @@ async function bootstrap() {
 	app.enableCors(CORS)
 	app.use(morgan('tiny'))
 	app.setGlobalPrefix('api')
+
+	const config = new DocumentBuilder()
+		.setTitle('Co-Workers Box')
+		.setDescription('The Co-Workers Box API - Endpoints & Description')
+		.setVersion('1.0')
+		.build()
+	const document = SwaggerModule.createDocument(app, config)
+	SwaggerModule.setup('docs', app, document)
 
 	await app.listen(process.env.PORT, () => {
 		console.log(`Servidor corriendo en http://localhost:${process.env.PORT}`)

--- a/src/packages/packages.controller.ts
+++ b/src/packages/packages.controller.ts
@@ -15,11 +15,14 @@ import { PackageDto } from './dto/package.dto'
 import { UpdatePackageDto } from './dto/update-package.dto'
 import { PACAKGE_STATUSES, PackageStatus } from './constants'
 import mongoose from 'mongoose'
+import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger'
 
+@ApiTags('Packages')
 @Controller('packages')
 export class PackagesController {
 	constructor(private packageService: PackagesService) {}
 
+	@ApiOperation({ description: 'List all users' })
 	@Get()
 	@HttpCode(HttpStatus.OK)
 	async findAll() {
@@ -30,6 +33,8 @@ export class PackagesController {
 		}
 	}
 
+	@ApiOperation({ description: 'List a specific package based on their ID' })
+	@ApiParam({ name: 'id', description: 'ID of the package', type: String })
 	@Get(':id')
 	@HttpCode(HttpStatus.OK)
 	async findBy(@Param('id') id: string) {
@@ -48,6 +53,12 @@ export class PackagesController {
 		}
 	}
 
+	@ApiOperation({ description: 'List all packages with a specific status' })
+	@ApiParam({
+		name: 'status',
+		description: 'Status of the package',
+		enum: PACAKGE_STATUSES,
+	})
 	@Get('/status/:status')
 	@HttpCode(HttpStatus.OK)
 	async findByStatus(@Param('status') status: PackageStatus) {
@@ -60,6 +71,8 @@ export class PackagesController {
 		}
 	}
 
+	@ApiOperation({ description: 'Create a new package' })
+	@ApiBody({ type: PackageDto })
 	@Post()
 	@HttpCode(HttpStatus.CREATED)
 	async create(@Body() createPackageDto: PackageDto) {
@@ -70,6 +83,9 @@ export class PackagesController {
 		}
 	}
 
+	@ApiOperation({ description: 'Update a specific package based on their ID' })
+	@ApiBody({ type: UpdatePackageDto })
+	@ApiParam({ name: 'id', description: 'ID of the package', type: String })
 	@Put(':id')
 	@HttpCode(HttpStatus.CREATED)
 	async update(@Param('id') id: string, @Body() data: UpdatePackageDto) {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -17,8 +17,10 @@ import { UpdateUserDto } from './dto/update-user.dto'
 import { UserDTO } from './dto/user.dto'
 import { PackagesService } from 'src/packages/packages.service'
 import { AddPackageDto } from './dto/add-package.dto'
+import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger'
 
 //Esto se crea con npx nest g controller <name>
+@ApiTags('Users')
 @Controller('users')
 export class UsersController {
 	constructor(
@@ -26,6 +28,8 @@ export class UsersController {
 		private readonly pacakgesServices: PackagesService
 	) {}
 
+	@ApiOperation({ description: 'Create a new user' })
+	@ApiBody({ type: UserDTO })
 	@Post()
 	@HttpCode(HttpStatus.CREATED)
 	async create(@Body() body: UserDTO) {
@@ -41,6 +45,7 @@ export class UsersController {
 		}
 	}
 
+	@ApiOperation({ description: 'List all users' })
 	@Get()
 	@HttpCode(HttpStatus.OK)
 	async findAll() {
@@ -51,6 +56,7 @@ export class UsersController {
 		}
 	}
 
+	@ApiOperation({ description: 'List all users with role Carrier' })
 	@Get('/carriers')
 	@HttpCode(HttpStatus.OK)
 	async findCarriers() {
@@ -61,6 +67,8 @@ export class UsersController {
 		}
 	}
 
+	@ApiOperation({ description: 'List a specific user based on their ID' })
+	@ApiParam({ name: 'id', description: 'ID of the user', type: String })
 	@Get(':id')
 	@HttpCode(HttpStatus.OK)
 	async findOne(@Param('id') id: string) {
@@ -85,6 +93,9 @@ export class UsersController {
 		}
 	}
 
+	@ApiOperation({ description: 'Update a specific user based on their ID' })
+	@ApiBody({ type: UpdateUserDto })
+	@ApiParam({ name: 'id', description: 'ID of the user', type: String })
 	@Put(':id')
 	@HttpCode(HttpStatus.OK)
 	async update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
@@ -128,6 +139,10 @@ export class UsersController {
 		}
 	}
 
+	@ApiOperation({
+		description: 'List a specific user associated packages, based on their ID',
+	})
+	@ApiParam({ name: 'userId', description: 'ID of the user', type: String })
 	@Get('/:userId/packages')
 	@HttpCode(HttpStatus.OK)
 	async getPackages(@Param('userId') id: string) {
@@ -151,6 +166,11 @@ export class UsersController {
 		}
 	}
 
+	@ApiOperation({
+		description: 'Add a package to a specific user, based on their ID',
+	})
+	@ApiBody({ type: AddPackageDto })
+	@ApiParam({ name: 'userId', description: 'ID of the user', type: String })
 	@Post('/:userId/package')
 	@HttpCode(HttpStatus.OK)
 	async addPackage(
@@ -173,6 +193,8 @@ export class UsersController {
 		return this.usersService.addPackageToUser(userId, pack._id.toString())
 	}
 
+	@ApiOperation({ description: 'Delete a specific user based on their ID' })
+	@ApiParam({ name: 'id', description: 'ID of the user', type: String })
 	@Delete(':id')
 	@HttpCode(HttpStatus.OK)
 	async remove(@Param('id') id: string) {
@@ -186,6 +208,15 @@ export class UsersController {
 		return this.usersService.remove(id)
 	}
 
+	@ApiOperation({
+		description: 'Remove a specific package from a user, based on their ID',
+	})
+	@ApiParam({ name: 'userId', description: 'ID of the user', type: String })
+	@ApiParam({
+		name: 'packageId',
+		description: 'ID of the package',
+		type: String,
+	})
 	@Patch('/:userId/removepackage/:packageId')
 	async removePackage(
 		@Param('userId') userId: string,


### PR DESCRIPTION
Configuración de Swagger en API, para documentación de los endpoints.

- Config en main.ts:

![Screenshot 2023-12-20 at 15 19 17](https://github.com/Francisco-Villanueva/box-api/assets/137815232/73a27dc7-bd68-4307-9b08-c6cbcb19e211)

- Se agregaron los decoradores de Swagger: ApiBody, ApiOperation, ApiParam, ApiTags en los controllers (users, packages, auth y app), con sus descripciones y requerimientos correspondientes.

- Con la API corriendo, pueden ingresar a http://localhost:3001/docs (la ruta /docs se establece en la configuración del main, linea 23 del screenshot anterior) y ahi se encuentra el panel con todo lo documentado:

![Screenshot 2023-12-20 at 15 17 03](https://github.com/Francisco-Villanueva/box-api/assets/137815232/5a35a175-1707-4165-a4a5-2f658f645fb7)

![Screenshot 2023-12-20 at 15 17 10](https://github.com/Francisco-Villanueva/box-api/assets/137815232/a2284455-5caf-4e8e-919f-242752cea02d)

- Ingresando a cualquier ruta/metodo se encuentra el detalle completo, con los body/params requeridos:

![Screenshot 2023-12-20 at 15 28 20](https://github.com/Francisco-Villanueva/box-api/assets/137815232/18a9de66-124b-46c9-87a0-2908f5456c88)

